### PR TITLE
Adds the ability to override the WSLAY_VERSION from a define.

### DIFF
--- a/lib/includes/wslay/wslay.h
+++ b/lib/includes/wslay/wslay.h
@@ -33,7 +33,9 @@ extern "C" {
 #include <stdlib.h>
 #include <sys/types.h>
 
-#include <wslay/wslayver.h>
+#ifndef WSLAY_VERSION
+#  include <wslay/wslayver.h>
+#endif /* WSLAY_VERSION */
 
 enum wslay_error {
   WSLAY_ERR_WANT_READ = -100,


### PR DESCRIPTION
This enables projects to set the build version from the compile environment
and avoid the need to generate the version header. In some build environments (such as
Windows without cygwin) and build generator systems like GYP this makes it much easier to just git submodule add wslay and use it on all platforms without having to autoconf.
