### PR TITLE
build: fix `./configure` when nettle is not present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,7 @@ AM_CONDITIONAL([HAVE_SPHINX_BUILD], [ test "x$SPHINX_BUILD" != "x" ])
 # Checks for libraries.
 
 # Nettle used in examples
-have_nettle=no
-PKG_CHECK_MODULES([NETTLE], [nettle >= 2.4], [have_nettle=yes])
+PKG_CHECK_MODULES([NETTLE], [nettle >= 2.4], [have_nettle=yes], [have_nettle=no])
 
 AC_CHECK_LIB([cunit], [CU_initialize_registry],
              [have_cunit=yes], [have_cunit=no])


### PR DESCRIPTION
`PKG_CHECK_MODULES` will fail unless we give it an action to execute on
failure. When nettle is not available, we set `have_nettle` to `no`.

BTW, I appreciate that you keep autotools. While integrating an autotools project inside a CMake project is quite easy, the reverse is quite difficult.
