### PR TITLE
Build examples only on Linux, since they use epoll

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,12 @@ AC_CHECK_FUNCS([ \
 
 build_examples=no
 if test "x${have_nettle}" = "xyes"; then
-  build_examples=yes
+  case $host_os in
+    linux*)
+      # the examples uses epoll
+      build_examples=yes
+      ;;
+  esac
 fi
 AM_CONDITIONAL([ENABLE_EXAMPLES], [ test "x${build_examples}" = "xyes" ])
 


### PR DESCRIPTION
The examples use `epoll`, and thus the build fails on OS X.  This PR is a workaround for the issue that simply turns off the `build_examples` flag on OSes other than Linux.

Last but foremost, thank you for writing wslay!
