### PR TITLE
Fix NULL check in wslay_frame_context_init.

### DIFF
--- a/lib/wslay_frame.c
+++ b/lib/wslay_frame.c
@@ -37,7 +37,7 @@ int wslay_frame_context_init(wslay_frame_context_ptr *ctx,
                              void *user_data)
 {
   *ctx = (wslay_frame_context_ptr)malloc(sizeof(struct wslay_frame_context));
-  if(ctx == NULL) {
+  if(*ctx == NULL) {
     return -1;
   }
   memset(*ctx, 0, sizeof(struct wslay_frame_context));


### PR DESCRIPTION
ctx == NULL is always false, as if it is true the line before would result in an segmentation fault.
