### PR TITLE
Require CMake 2.8, not 3.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 2.8)
 
 # This CMakeLists.txt file intended for:
 # - development of wslay library

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 2.8)
 
 # This CMakeLists.txt file intended for:
 # - include by master ../CMakeLists.txt


### PR DESCRIPTION
It seems that wslay's CMake build system works fine with cmake 2.8 (possibly earlier too).

Any chance you could apply this patch?

Great library btw.