### PR TITLE
Ignore residual cmake files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ tests/test-suite.log
 /build.*
 doc/man
 doc/sphinx/_build
+/CMakeFiles/
+/cmake_install.cmake
+/lib/cmake_install.cmake
+/lib/libwslay.a
+/wslay-config.cmake
+/wslay.cmake


### PR DESCRIPTION
This patch ignores output from in-source bulds with CMake.