### PR TITLE
Allow to stop receiving message from on_msg_recv_callback

### DIFF
--- a/lib/includes/wslay/wslay.h
+++ b/lib/includes/wslay/wslay.h
@@ -264,8 +264,12 @@ struct wslay_event_on_msg_recv_arg {
 /*
  * Callback function invoked by wslay_event_recv() when a message is
  * completely received.
+ *
+ * Return 0 if you want to continue to receive messages. Non-zero
+ * value will stop message processing and will cause
+ * wslay_event_recv() to return.
  */
-typedef void (*wslay_event_on_msg_recv_callback)
+typedef int (*wslay_event_on_msg_recv_callback)
 (wslay_event_context_ptr ctx,
  const struct wslay_event_on_msg_recv_arg *arg, void *user_data);
 

--- a/lib/wslay_event.c
+++ b/lib/wslay_event.c
@@ -538,7 +538,8 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
 {
   struct wslay_frame_iocb iocb;
   ssize_t r;
-  while(ctx->read_enabled) {
+  int stop = 0;
+  while(ctx->read_enabled && !stop) {
     memset(&iocb, 0, sizeof(iocb));
     r = wslay_frame_recv(ctx->frame_ctx, &iocb);
     if(r >= 0) {
@@ -715,7 +716,7 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
               arg.msg_length = msg_length;
               arg.status_code = status_code;
               ctx->error = 0;
-              ctx->callbacks.on_msg_recv_callback(ctx, &arg, ctx->user_data);
+              stop = ctx->callbacks.on_msg_recv_callback(ctx, &arg, ctx->user_data);
             }
             free(msg);
           }


### PR DESCRIPTION
I need a way to tell wslay to stop calling on_msg_recv_callback (because my message queue is already full and I only can drop message if they will continue to come) and to return. When I decide that I'm ready to receive more messages, I will call wslay_event_recv() once again.

Don't see any existing way to achieve that. Suggesting this patch to address this issue.