### PR TITLE
Allow RSV1 bit in event-based API for PMCE - RFC 7692

### DIFF
--- a/lib/includes/wslay/wslay.h
+++ b/lib/includes/wslay/wslay.h
@@ -145,10 +145,15 @@ enum wslay_opcode {
 #define wslay_is_ctrl_frame(opcode) ((opcode >> 3) & 1)
 
 /*
- * Macros that returns reserved bits: RSV1, RSV2, RSV3.  These macros
- * assumes that rsv is constructed by ((RSV1 << 2) | (RSV2 << 1) |
- * RSV3)
+ * Macros that represent and return reserved bits: RSV1, RSV2, RSV3.
+ * These macros assume that rsv is constructed by ((RSV1 << 2) |
+ * (RSV2 << 1) | RSV3)
  */
+#define WSLAY_RSV_NONE ((uint8_t) 0)
+#define WSLAY_RSV1_BIT (((uint8_t) 1) << 2)
+#define WSLAY_RSV2_BIT (((uint8_t) 1) << 1)
+#define WSLAY_RSV3_BIT (((uint8_t) 1) << 0)
+
 #define wslay_get_rsv1(rsv) ((rsv >> 2) & 1)
 #define wslay_get_rsv2(rsv) ((rsv >> 1) & 1)
 #define wslay_get_rsv3(rsv) (rsv & 1)
@@ -201,7 +206,7 @@ void wslay_frame_context_free(wslay_frame_context_ptr ctx);
  * 1 if this is masked frame, otherwise 0.  iocb->payload_length is
  * the payload_length of this frame.  iocb->data must point to the
  * payload data to be sent. iocb->data_length must be the length of
- * the data.  This function calls recv_callback function if it needs
+ * the data.  This function calls send_callback function if it needs
  * to send bytes.  This function calls gen_mask_callback function if
  * it needs new mask key.  This function returns the number of payload
  * bytes sent. Please note that it does not include any number of
@@ -408,6 +413,16 @@ int wslay_event_context_client_init
 void wslay_event_context_free(wslay_event_context_ptr ctx);
 
 /*
+ * Sets a bit mask of allowed reserved bits.
+ * Currently only permited values are WSLAY_RSV1_BIT to allow PMCE
+ * extension (see RFC-7692) or WSLAY_RSV_NONE to disable.
+ *
+ * Default: WSLAY_RSV_NONE
+ */
+void wslay_event_set_allowed_rsv_bits(wslay_event_context_ptr ctx,
+                                      uint8_t rsv);
+
+/*
  * Enables or disables buffering of an entire message for non-control
  * frames. If val is 0, buffering is enabled. Otherwise, buffering is
  * disabled. If wslay_event_on_msg_recv_callback is invoked when
@@ -551,6 +566,12 @@ int wslay_event_queue_msg(wslay_event_context_ptr ctx,
                           const struct wslay_event_msg *arg);
 
 /*
+ * Extended version of wslay_event_queue_msg which allows to set reserved bits.
+ */
+int wslay_event_queue_msg_ex(wslay_event_context_ptr ctx,
+                             const struct wslay_event_msg *arg, uint8_t rsv);
+
+/*
  * Specify "source" to generate message.
  */
 union wslay_event_msg_source {
@@ -606,6 +627,13 @@ struct wslay_event_fragmented_msg {
  */
 int wslay_event_queue_fragmented_msg
 (wslay_event_context_ptr ctx, const struct wslay_event_fragmented_msg *arg);
+
+/*
+ * Extended version of wslay_event_queue_fragmented_msg which allows to set
+ * reserved bits.
+ */
+int wslay_event_queue_fragmented_msg_ex(wslay_event_context_ptr ctx,
+    const struct wslay_event_fragmented_msg *arg, uint8_t rsv);
 
 /*
  * Queues close control frame. This function is provided just for

--- a/lib/wslay_event.c
+++ b/lib/wslay_event.c
@@ -206,7 +206,7 @@ static int wslay_event_imsg_append_chunk(struct wslay_event_imsg *m, size_t len)
 }
 
 static int wslay_event_omsg_non_fragmented_init
-(struct wslay_event_omsg **m, uint8_t opcode,
+(struct wslay_event_omsg **m, uint8_t opcode, uint8_t rsv,
  const uint8_t *msg, size_t msg_length)
 {
   *m = (struct wslay_event_omsg*)malloc(sizeof(struct wslay_event_omsg));
@@ -216,6 +216,7 @@ static int wslay_event_omsg_non_fragmented_init
   memset(*m, 0, sizeof(struct wslay_event_omsg));
   (*m)->fin = 1;
   (*m)->opcode = opcode;
+  (*m)->rsv = rsv;
   (*m)->type = WSLAY_NON_FRAGMENTED;
   if(msg_length) {
     (*m)->data = (uint8_t*)malloc(msg_length);
@@ -230,7 +231,7 @@ static int wslay_event_omsg_non_fragmented_init
 }
 
 static int wslay_event_omsg_fragmented_init
-(struct wslay_event_omsg **m, uint8_t opcode,
+(struct wslay_event_omsg **m, uint8_t opcode, uint8_t rsv,
  const union wslay_event_msg_source source,
  wslay_event_fragmented_msg_callback read_callback)
 {
@@ -240,6 +241,7 @@ static int wslay_event_omsg_fragmented_init
   }
   memset(*m, 0, sizeof(struct wslay_event_omsg));
   (*m)->opcode = opcode;
+  (*m)->rsv = rsv;
   (*m)->type = WSLAY_FRAGMENTED;
   (*m)->source = source;
   (*m)->read_callback = read_callback;
@@ -328,19 +330,33 @@ static int wslay_event_queue_close_wrapper
   return 0;
 }
 
+static int wslay_event_verify_rsv_bits(wslay_event_context_ptr ctx, uint8_t rsv)
+{
+  return ((rsv & ~ctx->allowed_rsv_bits) == 0);
+}
+
 int wslay_event_queue_msg(wslay_event_context_ptr ctx,
                           const struct wslay_event_msg *arg)
+{
+  return wslay_event_queue_msg_ex(ctx, arg, WSLAY_RSV_NONE);
+}
+
+int wslay_event_queue_msg_ex(wslay_event_context_ptr ctx,
+                              const struct wslay_event_msg *arg, uint8_t rsv)
 {
   int r;
   struct wslay_event_omsg *omsg;
   if(!wslay_event_is_msg_queueable(ctx)) {
     return WSLAY_ERR_NO_MORE_MSG;
   }
-  if(wslay_is_ctrl_frame(arg->opcode) && arg->msg_length > 125) {
+  /* RSV1 is not allowed for control frames */
+  if((wslay_is_ctrl_frame(arg->opcode) &&
+      (arg->msg_length > 125 || wslay_get_rsv1(rsv)))
+        || !wslay_event_verify_rsv_bits(ctx, rsv)) {
     return WSLAY_ERR_INVALID_ARGUMENT;
   }
   if((r = wslay_event_omsg_non_fragmented_init
-      (&omsg, arg->opcode, arg->msg, arg->msg_length)) != 0) {
+      (&omsg, arg->opcode, rsv, arg->msg, arg->msg_length)) != 0) {
     return r;
   }
   if(wslay_is_ctrl_frame(arg->opcode)) {
@@ -360,6 +376,12 @@ int wslay_event_queue_msg(wslay_event_context_ptr ctx,
 int wslay_event_queue_fragmented_msg
 (wslay_event_context_ptr ctx, const struct wslay_event_fragmented_msg *arg)
 {
+  return wslay_event_queue_fragmented_msg_ex(ctx, arg, WSLAY_RSV_NONE);
+}
+
+int wslay_event_queue_fragmented_msg_ex(wslay_event_context_ptr ctx,
+    const struct wslay_event_fragmented_msg *arg, uint8_t rsv)
+{
   int r;
   struct wslay_event_omsg *omsg;
   if(!wslay_event_is_msg_queueable(ctx)) {
@@ -369,7 +391,7 @@ int wslay_event_queue_fragmented_msg
     return WSLAY_ERR_INVALID_ARGUMENT;
   }
   if((r = wslay_event_omsg_fragmented_init
-      (&omsg, arg->opcode, arg->source, arg->read_callback)) != 0) {
+      (&omsg, arg->opcode, rsv, arg->source, arg->read_callback)) != 0) {
     return r;
   }
   if((r = wslay_queue_push(ctx->send_queue, omsg)) != 0) {
@@ -547,9 +569,11 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
     r = wslay_frame_recv(ctx->frame_ctx, &iocb);
     if(r >= 0) {
       int new_frame = 0;
-      /* We only allow rsv == 0 ATM. */
-      if(iocb.rsv != 0 ||
-         ((ctx->server && !iocb.mask) || (!ctx->server && iocb.mask))) {
+      /* RSV1 is not allowed on control and continuation frames */
+      if((!wslay_event_verify_rsv_bits(ctx, iocb.rsv)) ||
+          (wslay_get_rsv1(iocb.rsv) && (wslay_is_ctrl_frame(iocb.opcode) ||
+             iocb.opcode == WSLAY_CONTINUATION_FRAME)) ||
+               (ctx->server && !iocb.mask) || (!ctx->server && iocb.mask)) {
         if((r = wslay_event_queue_close_wrapper
             (ctx, WSLAY_CODE_PROTOCOL_ERROR, NULL, 0)) != 0) {
           return r;
@@ -608,8 +632,9 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
           }
         }
       }
-      if(ctx->imsg->opcode == WSLAY_TEXT_FRAME ||
-         ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
+      /* If RSV1 bit is set then it is too early for utf-8 validation */
+      if((!wslay_get_rsv1(iocb.rsv) && ctx->imsg->opcode == WSLAY_TEXT_FRAME)
+          || ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
         size_t i;
         if(ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
           i = 2;
@@ -815,6 +840,7 @@ int wslay_event_send(wslay_event_context_ptr ctx)
       memset(&iocb, 0, sizeof(iocb));
       iocb.fin = 1;
       iocb.opcode = ctx->omsg->opcode;
+      iocb.rsv = ctx->omsg->rsv;
       iocb.mask = ctx->server^1;
       iocb.data = ctx->omsg->data+ctx->opayloadoff;
       iocb.data_length = ctx->opayloadlen-ctx->opayloadoff;
@@ -871,6 +897,7 @@ int wslay_event_send(wslay_event_context_ptr ctx)
       memset(&iocb, 0, sizeof(iocb));
       iocb.fin = ctx->omsg->fin;
       iocb.opcode = ctx->omsg->opcode;
+      iocb.rsv = ctx->omsg->rsv;
       iocb.mask = ctx->server ? 0 : 1;
       iocb.data = ctx->obufmark;
       iocb.data_length = ctx->obuflimit-ctx->obufmark;
@@ -886,6 +913,8 @@ int wslay_event_send(wslay_event_context_ptr ctx)
             ctx->omsg = NULL;
           } else {
             ctx->omsg->opcode = WSLAY_CONTINUATION_FRAME;
+            /* RSV1 is not set on continuation frames */
+            ctx->omsg->rsv = ctx->omsg->rsv & ~WSLAY_RSV1_BIT;
           }
         } else {
           break;
@@ -949,6 +978,14 @@ int wslay_event_get_close_received(wslay_event_context_ptr ctx)
 int wslay_event_get_close_sent(wslay_event_context_ptr ctx)
 {
   return (ctx->close_status & WSLAY_CLOSE_SENT) > 0;
+}
+
+void wslay_event_set_allowed_rsv_bits(wslay_event_context_ptr ctx,
+                                      uint8_t rsv)
+{
+  /* We currently only allow WSLAY_RSV1_BIT or WSLAY_RSV_NONE */
+  if((rsv & ~WSLAY_RSV1_BIT) == 0)
+    ctx->allowed_rsv_bits = rsv;
 }
 
 void wslay_event_config_set_no_buffering(wslay_event_context_ptr ctx, int val)

--- a/lib/wslay_event.h
+++ b/lib/wslay_event.h
@@ -56,6 +56,7 @@ enum wslay_event_msg_type {
 struct wslay_event_omsg {
   uint8_t fin;
   uint8_t opcode;
+  uint8_t rsv;
   enum wslay_event_msg_type type;
 
   uint8_t *data;
@@ -135,6 +136,7 @@ struct wslay_event_context {
   struct wslay_event_callbacks callbacks;
   struct wslay_event_frame_user_data frame_user_data;
   void *user_data;
+  uint8_t allowed_rsv_bits;
 };
 
 #endif /* WSLAY_EVENT_H */


### PR DESCRIPTION
Add a new function wslay_event_set_allowed_rsv_bits which only accpet
RSV1 for now (or 0 to disable).

Skip UTF-8 validation on frames with RSV1 set as it is too early for that.

Add extended versions of wslay_event_queue_msg functions which also take
the reserved bits to set for this message.

See #30 