### PR TITLE
Skip UTF-8 validation for PMCE fragments

### DIFF
--- a/doc/sphinx/man/wslay_event_config_set_allowed_rsv_bits.rst
+++ b/doc/sphinx/man/wslay_event_config_set_allowed_rsv_bits.rst
@@ -14,7 +14,7 @@ DESCRIPTION
 -----------
 
 :c:func:`wslay_event_config_set_allowed_rsv_bits` sets a bit mask of
-allowed reserved bits (RSVs).  Currently only permited values are
+allowed reserved bits (RSVs).  Currently only permitted values are
 ``WSLAY_RSV1_BIT`` to allow PMCE extension (see :rfc:`7692`) or
 ``WSLAY_RSV_NONE`` to disable.
 

--- a/lib/includes/wslay/wslay.h
+++ b/lib/includes/wslay/wslay.h
@@ -414,7 +414,7 @@ void wslay_event_context_free(wslay_event_context_ptr ctx);
 
 /*
  * Sets a bit mask of allowed reserved bits.
- * Currently only permited values are WSLAY_RSV1_BIT to allow PMCE
+ * Currently only permitted values are WSLAY_RSV1_BIT to allow PMCE
  * extension (see RFC-7692) or WSLAY_RSV_NONE to disable.
  *
  * Default: WSLAY_RSV_NONE

--- a/lib/wslay_event.c
+++ b/lib/wslay_event.c
@@ -634,8 +634,9 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
         }
       }
       /* If RSV1 bit is set then it is too early for utf-8 validation */
-      if((!wslay_get_rsv1(iocb.rsv) && ctx->imsg->opcode == WSLAY_TEXT_FRAME)
-          || ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
+      if((!wslay_get_rsv1(ctx->imsg->rsv) &&
+          ctx->imsg->opcode == WSLAY_TEXT_FRAME) ||
+            ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
         size_t i;
         if(ctx->imsg->opcode == WSLAY_CONNECTION_CLOSE) {
           i = 2;


### PR DESCRIPTION
If the message was marked with rsv1 on the inital frame then
we should skip utf-8 validation on subsequent continuation
frames as well.

Added test for this case.

Found by autobahn wstest tool.