### PR TITLE
check for 0 length before memcpy:

### DIFF
--- a/lib/wslay_event.c
+++ b/lib/wslay_event.c
@@ -303,7 +303,8 @@ int wslay_event_queue_close(wslay_event_context_ptr ctx, uint16_t status_code,
     } else {
       ncode = htons(status_code);
       memcpy(msg, &ncode, 2);
-      memcpy(msg+2, reason, reason_length);
+      if(reason_length)
+        memcpy(msg+2, reason, reason_length);
       msg_length = reason_length+2;
     }
     arg.opcode = WSLAY_CONNECTION_CLOSE;


### PR DESCRIPTION
Otherwise I get this warning from -fsanitize=undefined

.../wslay/lib/wslay_event.c:304:7: runtime error: null pointer passed as argument 2, which is declared to never be null