### PR TITLE
Fix compilation of examples

### DIFF
--- a/examples/echoserv.cc
+++ b/examples/echoserv.cc
@@ -122,7 +122,7 @@ std::string base64(const std::string& src)
   base64_encode_ctx ctx;
   base64_encode_init(&ctx);
   int dstlen = BASE64_ENCODE_RAW_LENGTH(src.size());
-  uint8_t *dst = new uint8_t[dstlen];
+  char *dst = new char[dstlen];
   base64_encode_raw(dst, src.size(), reinterpret_cast<const uint8_t*>(src.c_str()));
   std::string res(&dst[0], &dst[dstlen]);
   delete [] dst;

--- a/examples/testclient.cc
+++ b/examples/testclient.cc
@@ -113,7 +113,7 @@ std::string base64(const std::string& src)
   base64_encode_ctx ctx;
   base64_encode_init(&ctx);
   int dstlen = BASE64_ENCODE_RAW_LENGTH(src.size());
-  uint8_t *dst = new uint8_t[dstlen];
+  char *dst = new char[dstlen];
   base64_encode_raw(dst, src.size(),
                     reinterpret_cast<const uint8_t*>(src.c_str()));
   std::string res(&dst[0], &dst[dstlen]);


### PR DESCRIPTION
Since 3.4 nettle defines base64_encode_raw like this:

    void base64_encode_raw(char *dst, size_t length, const uint8_t *src);

So examples have to be adjusted. More read at
https://git.lysator.liu.se/nettle/nettle/blob/nettle_3.4_release_20171119/NEWS#L49-53