### PR TITLE
Fix warning with -Wshadow

### DIFF
--- a/lib/wslay_event.c
+++ b/lib/wslay_event.c
@@ -730,11 +730,11 @@ int wslay_event_recv(wslay_event_context_ptr ctx)
                 return r;
               }
             } else if(ctx->imsg->opcode == WSLAY_PING) {
-              struct wslay_event_msg arg;
-              arg.opcode = WSLAY_PONG;
-              arg.msg = msg;
-              arg.msg_length = ctx->imsg->msg_length;
-              if((r = wslay_event_queue_msg(ctx, &arg)) &&
+              struct wslay_event_msg pong_arg;
+              pong_arg.opcode = WSLAY_PONG;
+              pong_arg.msg = msg;
+              pong_arg.msg_length = ctx->imsg->msg_length;
+              if((r = wslay_event_queue_msg(ctx, &pong_arg)) &&
                  r != WSLAY_ERR_NO_MORE_MSG) {
                 ctx->read_enabled = 0;
                 free(msg);


### PR DESCRIPTION
Thanks for a great library. I turn on -Wshadow at the top level of my cmake and since wslay turns on Werror it fails to compile without this fix.