### PR TITLE
Handle missing arpa/inet.h header

### DIFF
--- a/lib/wslay_net.h
+++ b/lib/wslay_net.h
@@ -33,6 +33,16 @@
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
+#elif defined(WORDS_BIGENDIAN)
+#  define htonl(x) (x)
+#  define htons(x) (x)
+#  define ntohl(x) (x)
+#  define ntohs(x) (x)
+#else
+#  define htonl(x) __builtin_bswap32(x)
+#  define htons(x) __builtin_bswap16(x)
+#  define ntohl(x) __builtin_bswap32(x)
+#  define ntohs(x) __builtin_bswap16(x)
 #endif /* HAVE_ARPA_INET_H */
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>


### PR DESCRIPTION
Though wslay makes `arpa/inet.h` optional, it depends on the `htonl`, `htons`, `ntohl` and `ntohs` functions of what causes builds to fail on systems without that header. This commit adds macros to replace these functions if the header is missing, so one can also build wslay without it, for example for embedded devices like game consoles.