### PR TITLE
docs: fix simple typo, previouly -> previously

### DIFF
--- a/lib/includes/wslay/wslay.h
+++ b/lib/includes/wslay/wslay.h
@@ -452,7 +452,7 @@ void wslay_event_config_set_max_recv_msg_length(wslay_event_context_ptr ctx,
                                                 uint64_t val);
 
 /*
- * Sets callbacks to ctx. The callbacks previouly set by this function
+ * Sets callbacks to ctx. The callbacks previously set by this function
  * or wslay_event_context_server_init() or
  * wslay_event_context_client_init() are replaced with callbacks.
  */


### PR DESCRIPTION
There is a small typo in lib/includes/wslay/wslay.h.

Should read `previously` rather than `previouly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md