### PR TITLE
Fix warning for extraneous comma.

### DIFF
--- a/lib/wslay_frame.c
+++ b/lib/wslay_frame.c
@@ -109,7 +109,7 @@ ssize_t wslay_frame_send(wslay_frame_context_ptr ctx,
     int flags = 0;
     if (iocb->data_length > 0) {
       flags |= WSLAY_MSG_MORE;
-    };
+    }
     r = ctx->callbacks.send_callback(ctx->oheadermark, (size_t)len, flags,
                                      ctx->user_data);
     if (r > 0) {


### PR DESCRIPTION
This fixes this warning:


.../wslay/lib/wslay_frame.c:116:6: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
    };
     ^
